### PR TITLE
Add missing include for stdbool.h

### DIFF
--- a/box.h
+++ b/box.h
@@ -26,6 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <chipmunk/chipmunk.h>
+#include <stdbool.h>
 
 #include "draw.h"
 


### PR DESCRIPTION
It seems needed to build with GCC 4.9.2
